### PR TITLE
Simple fix for AWS instances date with no tags

### DIFF
--- a/src/verinfast/cloud/aws/instances.py
+++ b/src/verinfast/cloud/aws/instances.py
@@ -177,8 +177,6 @@ def get_instances(sub_id: int, path_to_output: str = "./",
                         for instance in instances:
                             tags = instance.get('Tags')
                             if tags is None:
-                                tags = instance['Tags']
-                            if tags is None:
                                 name = instance["InstanceId"]
                             else:
                                 tags_with_name = [t['Value'] for t in tags if t['Key'] == 'Name']  # noqa: E501

--- a/src/verinfast/cloud/aws/instances.py
+++ b/src/verinfast/cloud/aws/instances.py
@@ -175,7 +175,8 @@ def get_instances(sub_id: int, path_to_output: str = "./",
                     for reservation in reservations:
                         instances = reservation['Instances']
                         for instance in instances:
-                            if 'Tags' in instance:
+                            tags = instance.get('Tags')
+                            if tags is None:
                                 tags = instance['Tags']
                             if tags is None:
                                 name = instance["InstanceId"]

--- a/src/verinfast/cloud/aws/instances.py
+++ b/src/verinfast/cloud/aws/instances.py
@@ -175,7 +175,8 @@ def get_instances(sub_id: int, path_to_output: str = "./",
                     for reservation in reservations:
                         instances = reservation['Instances']
                         for instance in instances:
-                            tags = instance['Tags']
+                            if 'Tags' in instance:
+                                tags = instance['Tags']
                             if tags is None:
                                 name = instance["InstanceId"]
                             else:


### PR DESCRIPTION
<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Sometimes AWS instance have no tags. We weren't adequately checking that the field is missing.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses an issue where AWS instances without tags were not being adequately checked, potentially causing errors. A conditional check was added to ensure the 'Tags' field is present before attempting to access it.

- **Bug Fixes**:
    - Added a check to handle AWS instances that have no tags, preventing potential errors when the 'Tags' field is missing.

<!-- Generated by sourcery-ai[bot]: end summary -->