### PR TITLE
More error catching for Azure instances

### DIFF
--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -755,7 +755,8 @@ class Agent:
                     azure_instance_file = get_az_instances(
                         sub_id=provider.account,
                         path_to_output=self.config.output_dir,
-                        dry=self.config.dry
+                        dry=self.config.dry,
+                        log=self.log
                     )
                     if azure_instance_file is None:
                         self.log(msg="Error processing Azure instances", tag=provider.account)

--- a/src/verinfast/cloud/azure/instances.py
+++ b/src/verinfast/cloud/azure/instances.py
@@ -68,7 +68,12 @@ def get_metrics_for_instance(
     return data
 
 
-def get_instances(sub_id: str, path_to_output: str = "./", dry=False):
+def get_instances(
+        sub_id: str,
+        path_to_output: str = "./",
+        dry=False,
+        log=None
+        ):
 
     if not dry:
         my_instances = []
@@ -87,7 +92,7 @@ def get_instances(sub_id: str, path_to_output: str = "./", dry=False):
             )
 
         res = client.virtual_machines.list_all()
-        print(my_instances)
+
         for vm in res:
             try:
                 s = vm.storage_profile.os_disk.managed_disk.id
@@ -136,7 +141,8 @@ def get_instances(sub_id: str, path_to_output: str = "./", dry=False):
                     "publicIp": public_ip,
                     "vpc": vnet_name
                 }
-            except KeyError:
+            except Exception as e:
+                log(tag="Azure Get Instance Error:", msg=e)
                 continue
             my_instances.append(my_instance)
             m = get_metrics_for_instance(

--- a/src/verinfast/cloud/azure/instances.py
+++ b/src/verinfast/cloud/azure/instances.py
@@ -142,7 +142,11 @@ def get_instances(
                     "vpc": vnet_name
                 }
             except Exception as e:
-                log(tag="Azure Get Instance Error:", msg=e)
+                if log:
+                    log(
+                        tag="Azure Get Instance Error",
+                        msg=str(e)
+                    )
                 continue
             my_instances.append(my_instance)
             m = get_metrics_for_instance(


### PR DESCRIPTION
<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

User saw this error while scanning Azure:
2024-06-25 12:11:12 ERROR: list index out of range
2024-06-25 12:11:12 ERROR STACK: Traceback (most recent call last):
  File "/mnt/c/dev/DebbieJ/StartupOS_Verinfast/src/verinfast/agent.py", line 742, in scanCloud
    azure_instance_file = get_az_instances(
  File "/home/djackson/.local/lib/python3.10/site-packages/verinfast/cloud/azure/instances.py", line 94, in get_instances
    tgt = s.split('resourceGroups/')[1]
IndexError: list index out of range

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request improves error handling and logging for Azure instance retrieval, addressing a specific 'list index out of range' error and enhancing the overall robustness of the Azure scanning process.

- **Bug Fixes**:
    - Added error handling to catch and log exceptions during Azure instance retrieval to prevent 'list index out of range' errors.
- **Enhancements**:
    - Introduced a logging mechanism to capture and log errors in the `get_instances` function for better debugging and monitoring.

<!-- Generated by sourcery-ai[bot]: end summary -->