### PR TITLE
Fix for malformed aws instance uploads

### DIFF
--- a/src/verinfast/cloud/aws/instances.py
+++ b/src/verinfast/cloud/aws/instances.py
@@ -146,7 +146,7 @@ def get_instance_utilization(
 
 
 def get_instances(sub_id: int, path_to_output: str = "./",
-                  dry=False) -> str | None:
+                  dry=False, log=None) -> str | None:
     if not dry:
         session = boto3.Session()
         profiles = session.available_profiles
@@ -207,15 +207,22 @@ def get_instances(sub_id: int, path_to_output: str = "./",
                             try:
                                 result = {
                                     "id": instance["InstanceId"],
-                                    "name": name,
+                                    "name": name if name else 'n/a',
                                     "state": instance["State"]["Name"],
                                     "type": instance['InstanceType'],
-                                    "zone": zone,
-                                    "region": region,
-                                    "subnet": subnet_id,
+                                    "zone": zone if zone else 'n/a',
+                                    "region": region if region else 'n/a',
+                                    "subnet": (
+                                        subnet_id if subnet_id else 'n/a'
+                                    ),
                                     "architecture": instance['Architecture']
                                 }
-                            except KeyError:
+                            except Exception as e:
+                                if log:
+                                    log(
+                                        tag="AWS Get Instance Error",
+                                        msg=str(e)
+                                    )
                                 continue
                             if "VpcId" in instance:
                                 result["vpc"] = instance['VpcId']


### PR DESCRIPTION
<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

A user could not upload AWS instance data because "subnet" was null. This catches and fixes that.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug where AWS instance uploads would fail if the 'subnet' field was null. Default values are now provided for missing fields, and logging has been added to capture exceptions during data retrieval.

- **Bug Fixes**:
    - Fixed issue where AWS instance uploads would fail due to null 'subnet' values by providing default values for missing fields.
- **Enhancements**:
    - Added logging for exceptions during AWS instance data retrieval to aid in debugging.

<!-- Generated by sourcery-ai[bot]: end summary -->