### PR TITLE
Catch more errors during AWS instances region checks

### DIFF
--- a/src/verinfast/cloud/aws/instances.py
+++ b/src/verinfast/cloud/aws/instances.py
@@ -241,7 +241,12 @@ def get_instances(sub_id: int, path_to_output: str = "./",
                                             public_ip = association['PublicIp']
                                             result["publicIp"] = public_ip
                             my_instances.append(result)
-            except botocore.exceptions.ClientError:
+            except Exception as e:
+                if log:
+                    log(
+                        tag="AWS Get Instance Error - Region",
+                        msg=str(e)
+                    )
                 pass
 
         upload = {


### PR DESCRIPTION
<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, if the user of TechLens has a firewall that blocks access to say AWS Africa, the cloud scan breaks.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Improve error handling in AWS instance region checks by catching and logging general exceptions to prevent cloud scan disruptions.

Bug Fixes:
- Catch and log more general exceptions during AWS instance region checks to prevent cloud scan failures when access is blocked by firewalls.

<!-- Generated by sourcery-ai[bot]: end summary -->