### PR TITLE
making it a string

### DIFF
--- a/src/verinfast/cloud/gcp/blocks.py
+++ b/src/verinfast/cloud/gcp/blocks.py
@@ -43,7 +43,7 @@ def getBlocks(sub_id: str, path_to_output: str = "./", dry=False):
             known_buckets[bucket.name] = {
                 "name": bucket.name,
                 "size": 0,
-                "retention": rp,
+                "retention": str(rp),
                 "public": False
             }
             iam = bucket.get_iam_policy()


### PR DESCRIPTION
<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Downstream API expects string.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
SOS-749
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Convert the 'retention' field to a string in the GCP blocks module to ensure compatibility with a downstream API.

Bug Fixes:
- Convert the 'retention' value to a string to meet the expectations of a downstream API.

<!-- Generated by sourcery-ai[bot]: end summary -->