### PR TITLE
Fix for Azure output filenames

### DIFF
--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -767,7 +767,7 @@ class Agent:
                         )
                     azure_utilization_file = os.path.join(
                         self.config.output_dir,
-                        f'azure-instances-{provider.account}-utilization.json'
+                        f'az-instances-{provider.account}-utilization.json'
                     )
                     if Path(azure_utilization_file).is_file():
                         self.upload(

--- a/src/verinfast/cloud/azure/blocks.py
+++ b/src/verinfast/cloud/azure/blocks.py
@@ -82,7 +82,7 @@ def getBlocks(sub_id: str, path_to_output: str = "./", dry=False):
     # End dry block
     azure_output_file = os.path.join(
         path_to_output,
-        f'azure-storage-{sub_id}.json'
+        f'az-storage-{sub_id}.json'
     )
     if not dry:
         with open(azure_output_file, 'w') as outfile:


### PR DESCRIPTION
<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Filenames for instances and instances-utilization didn't match for Azure, breaking uploads.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix Azure output filenames to match expected patterns, resolving issues with file uploads.

Bug Fixes:
- Correct filenames for Azure instances and storage outputs to ensure successful uploads.

<!-- Generated by sourcery-ai[bot]: end summary -->