### PR TITLE
Better error checking for AWS costs

### DIFF
--- a/src/verinfast/cloud/aws/costs.py
+++ b/src/verinfast/cloud/aws/costs.py
@@ -35,7 +35,7 @@ def runAws(targeted_account, start, end, path_to_output,
             raise Exception("Error getting aws cli data.")
 
         text = results.stdout.decode()
-        if text is None or isinstance(text, str) is False:
+        if text is None or text == '' or isinstance(text, str) is False:
             log(msg="No data returned from AWS CLI get-cost-and-usage",
                 tag="AWS CLI")
             return None


### PR DESCRIPTION
<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There was a user using AWS via Rackspace and they could not get access to AWS costs. They saw the error:
`json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`
I was able to reproduce with this test code on line 43 of /aws/costs.py:
`obj = json.loads('')`
so I added better error checking above.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.