### PR TITLE
Changing import methods to better support pipx installs

### DIFF
--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -286,7 +286,7 @@ class Agent:
 
         # Git Stats
         git_output_file = os.path.join(self.config.output_dir, repo_name + ".git.log.json")
-        if self.config.runGitStats:
+        if self.config.runGit:
             self.log(msg=repo_name, tag="Gathering source code statistics for", display=True)
             command = f'''git log \
                 --since="{self.config.modules.code.git.start}" \

--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -13,13 +13,12 @@ import io
 from uuid import uuid4
 
 from modernmetric.__main__ import main as modernmetric
-import semgrep
+import semgrep.commands.scan as semgrep_scan
 
 import httpx
 from jinja2 import Environment, FileSystemLoader
 from pygments_tsx.tsx import patch_pygments
-import semgrep.commands
-import semgrep.commands.scan
+
 from verinfast.utils.utils import DebugLog, std_exec, trimLineBreaks, escapeChars, truncate, truncate_children, get_repo_name_url_and_branch
 from verinfast.upload import Uploader
 from verinfast.cloud.aws.costs import runAws
@@ -451,7 +450,7 @@ class Agent:
                         ]
                         try:
                             with contextlib.redirect_stdout(io.StringIO()):
-                                semgrep.commands.scan.scan(custom_args)
+                                semgrep_scan.scan(custom_args)
                         except SystemExit:
                             pass
                 except Exception as e:

--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -33,6 +33,13 @@ from verinfast.user import initial_prompt, save_path, repeat_boolean_prompt
 
 from verinfast.dependencies.walk import walk as dependency_walk
 
+
+# import sys
+from semgrep.commands import scan as semgrep
+# print(dir(semgrep))
+# help(semgrep)
+# sys.exit(0)
+
 # from verinfast.pygments_patch import patch_pygments
 
 patch_pygments()
@@ -434,90 +441,100 @@ class Agent:
                 Please see the open issues here:
                 https://github.com/returntocorp/semgrep/issues/1330
                          """)
-            if self.checkDependency('semgrep', "Semgrep"):
-                findings_output_file = os.path.join(self.config.output_dir, repo_name + ".findings.json")
-                findings_error_file = os.path.join(self.config.output_dir, repo_name + ".findings.err")
-                if not self.config.dry:
-                    self.log(msg=repo_name, tag="Scanning repository", display=True)
-                    try:
-                        with open(findings_error_file, 'a') as e:
-                            subprocess.check_call([
-                                "semgrep",
-                                "scan",
-                                "--config",
-                                "auto",
-                                "--json",
-                                "-o",
-                                findings_output_file,
-                            ], stderr=e,)
-                    except subprocess.CalledProcessError as e:
-                        output = e.output
-                        self.log(msg=output, tag="Scanning repository return", display=True)
+
+            findings_output_file = os.path.join(self.config.output_dir, repo_name + ".findings.json")
+            findings_error_file = os.path.join(self.config.output_dir, repo_name + ".findings.err")
+            if not self.config.dry:
+                self.log(msg=repo_name, tag="Scanning repository", display=True)
                 try:
-                    with open(findings_output_file) as f:
-                        findings = json.load(f)
-
-                    # This is on purpose. If you try to read same pointer
-                    # twice, it dies.
-                    with open(findings_output_file) as f:
-                        original_findings = json.load(f)
-
-                    if self.config.truncate_findings:
-                        # Exclusions are set to exclude fields that are not code
-                        truncation_exclusion = [
-                            "cwe",
-                            "owasp",
-                            "path",
-                            "check_id",
-                            "license",
-                            "fingerprint",
-                            "message",
-                            "references",
-                            "url",
-                            "source",
-                            "severity"
+                    with open(findings_error_file, 'a') as e:
+                        custom_args = [
+                            "--config",
+                            "auto",
+                            "--json",
+                            "-o",
+                            findings_output_file
                         ]
-                        self.log(
-                            tag="TRUNCATING",
-                            msg=f"excluding: {truncation_exclusion}"
-                        )
-                        try:
-                            findings = truncate_children(
-                                findings,
-                                self.log,
-                                excludes=truncation_exclusion,
-                                max_length=self.config.truncate_findings_length
-                            )
-                        except Exception as e:
-                            self.log(tag="ERROR", msg="Error in Truncation")
-                            self.log(e)
-                            self.log(
-                                json.dumps(
-                                    original_findings,
-                                    indent=4,
-                                    sort_keys=True
-                                )
-                            )
-                    with open(findings_output_file, "w") as f2:
-                        f2.write(json.dumps(
-                            findings, indent=4, sort_keys=True
-                        ))
-                    template_definition["gitfindings"] = findings
+                        print("custom_args", custom_args)
+                        semgrep.scan(custom_args)
+                        print("here")
+                        # subprocess.check_call([
+                        #     "semgrep",
+                        #     "scan",
+                        #     "--config",
+                        #     "auto",
+                        #     "--json",
+                        #     "-o",
+                        #     findings_output_file,
+                        # ], stderr=e,)
                 except Exception as e:
-                    if not self.config.dry:
-                        raise e
-                    else:
-                        self.log(
-                            msg=f'''
-                                Attempted to format/truncate non existent file
-                                {findings_output_file}
-                            '''
+                    self.log(tag="ERROR", msg="Error in Semgrep")
+                    self.log(e)
+            try:
+                with open(findings_output_file) as f:
+                    findings = json.load(f)
+
+                # This is on purpose. If you try to read same pointer
+                # twice, it dies.
+                with open(findings_output_file) as f:
+                    original_findings = json.load(f)
+
+                if self.config.truncate_findings:
+                    # Exclusions are set to exclude fields that are not code
+                    truncation_exclusion = [
+                        "cwe",
+                        "owasp",
+                        "path",
+                        "check_id",
+                        "license",
+                        "fingerprint",
+                        "message",
+                        "references",
+                        "url",
+                        "source",
+                        "severity"
+                    ]
+                    self.log(
+                        tag="TRUNCATING",
+                        msg=f"excluding: {truncation_exclusion}"
+                    )
+                    try:
+                        findings = truncate_children(
+                            findings,
+                            self.log,
+                            excludes=truncation_exclusion,
+                            max_length=self.config.truncate_findings_length
                         )
-                self.upload(
-                    file=findings_output_file,
-                    route="findings",
-                    source=repo_name
-                )
+                    except Exception as e:
+                        self.log(tag="ERROR", msg="Error in Truncation")
+                        self.log(e)
+                        self.log(
+                            json.dumps(
+                                original_findings,
+                                indent=4,
+                                sort_keys=True
+                            )
+                        )
+                with open(findings_output_file, "w") as f2:
+                    f2.write(json.dumps(
+                        findings, indent=4, sort_keys=True
+                    ))
+                template_definition["gitfindings"] = findings
+            except Exception as e:
+                if not self.config.dry:
+                    raise e
+                else:
+                    self.log(
+                        msg=f'''
+                            Attempted to format/truncate non existent file
+                            {findings_output_file}
+                        '''
+                    )
+            self.upload(
+                file=findings_output_file,
+                route="findings",
+                source=repo_name
+            )
 
         # ##### Scan Dependencies ######
         if self.config.runDependencies:

--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -13,19 +13,15 @@ import io
 from uuid import uuid4
 
 from modernmetric.__main__ import main as modernmetric
+import semgrep
 
 import httpx
 from jinja2 import Environment, FileSystemLoader
 from pygments_tsx.tsx import patch_pygments
 import semgrep.commands
 import semgrep.commands.scan
-import semgrep.external
-import semgrep.main
-import semgrep.run_scan
-
 from verinfast.utils.utils import DebugLog, std_exec, trimLineBreaks, escapeChars, truncate, truncate_children, get_repo_name_url_and_branch
 from verinfast.upload import Uploader
-
 from verinfast.cloud.aws.costs import runAws
 from verinfast.cloud.aws.get_profile import find_profile
 from verinfast.cloud.azure.costs import runAzure
@@ -37,21 +33,8 @@ from verinfast.cloud.azure.blocks import getBlocks as get_az_blocks
 from verinfast.cloud.gcp.blocks import getBlocks as get_gcp_blocks
 from verinfast.config import Config
 from verinfast.user import initial_prompt, save_path, repeat_boolean_prompt
-
 from verinfast.dependencies.walk import walk as dependency_walk
 
-
-# import sys
-# from semgrep.commands import main as semgrep
-# import semgrep.main as semgrep
-import semgrep
-
-# print(dir(semgrep.scan))
-# help(semgrep.scan)
-# sys.exit(0)
-
-
-# from verinfast.pygments_patch import patch_pygments
 
 patch_pygments()
 
@@ -466,44 +449,11 @@ class Agent:
                             f"--json-output={findings_output_file}",
                             "-q"
                         ]
-                        print("custom_args", custom_args)
-                        # semgrep.run_scan_and_return_json(
-                        #     targets=["."],
-                        #     **custom_args
-                        # )
-                        # semgrep.run_scan.run_scan()
-                        # semgrep.run_scan.run_scan([])
                         try:
                             with contextlib.redirect_stdout(io.StringIO()):
-                                semgrep.commands.scan.scan(
-                                    custom_args
-                                )
+                                semgrep.commands.scan.scan(custom_args)
                         except SystemExit:
                             pass
-
-                        # semgrep.main.main(["scan", "--config", "auto", "--json", "-o", findings_output_file])
-                        # semgrep.main.main()
-                        # semgrep.main.main(custom_args)
-                        # semgrep.main.main(**custom_args)
-                        # semgrep.run_scan(
-                        #     target=["."],
-                        #     output_handler=o,
-                        #     pattern="auto"
-                        # )
-                        # semgrep.run_scan(
-                        #     configs
-                        # )
-                        # semgrep.main(custom_args)
-                        print("here")
-                        # subprocess.check_call([
-                        #     "semgrep",
-                        #     "scan",
-                        #     "--config",
-                        #     "auto",
-                        #     "--json",
-                        #     "-o",
-                        #     findings_output_file,
-                        # ], stderr=e,)
                 except Exception as e:
                     self.log(tag="ERROR", msg="Error in Semgrep")
                     self.log(e)

--- a/src/verinfast/config.py
+++ b/src/verinfast/config.py
@@ -167,7 +167,6 @@ class Config(printable):
     reportId: int = 0
     runDependencies: bool = True
     runGit: bool = True
-    runGitStats: bool = True
     runScan: bool = True
     runSizes: bool = True
     runStats: bool = True
@@ -466,8 +465,6 @@ class Config(printable):
                     c = m["code"]
                     if "run_git" in c:
                         self.runGit = c["run_git"]
-                    if "run_git_stats" in c:
-                        self.runGitStats = c["run_git_stats"]
                     if "run_scan" in c:
                         self.runScan = c["run_scan"]
                     if "run_sizes" in c:

--- a/src/verinfast/config.py
+++ b/src/verinfast/config.py
@@ -167,6 +167,7 @@ class Config(printable):
     reportId: int = 0
     runDependencies: bool = True
     runGit: bool = True
+    runGitStats: bool = True
     runScan: bool = True
     runSizes: bool = True
     runStats: bool = True
@@ -242,8 +243,7 @@ class Config(printable):
             "repos" in self.config and
             "modules" in self.config and
             "code" in self.config["modules"] and
-            "git" in self.config["modules"]["code"] and
-            "run_git" not in self.config["modules"]["code"]
+            "git" in self.config["modules"]["code"]
         ):
             self.runGit = True
         self.upload_conf = UploadConfig(
@@ -466,6 +466,8 @@ class Config(printable):
                     c = m["code"]
                     if "run_git" in c:
                         self.runGit = c["run_git"]
+                    if "run_git_stats" in c:
+                        self.runGitStats = c["run_git_stats"]
                     if "run_scan" in c:
                         self.runScan = c["run_scan"]
                     if "run_sizes" in c:

--- a/src/verinfast/config.py
+++ b/src/verinfast/config.py
@@ -242,7 +242,8 @@ class Config(printable):
             "repos" in self.config and
             "modules" in self.config and
             "code" in self.config["modules"] and
-            "git" in self.config["modules"]["code"]
+            "git" in self.config["modules"]["code"] and
+            "run_git" not in self.config["modules"]["code"]
         ):
             self.runGit = True
         self.upload_conf = UploadConfig(


### PR DESCRIPTION
<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Non-pipx installs won't work with some subprocess calls. This amends that.
Also added config flag for "run_git_stats". "run_git" was being overloaded for fetching repo and running git stats. When testing other parts of the code, it was very annoying to not be able to disable other scan modules.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## Summary by Sourcery

Add a new configuration option 'runGitStats' to allow independent control of git statistics gathering, and refactor subprocess calls to enhance compatibility with pipx installations.

New Features:
- Introduce a new configuration flag 'runGitStats' to separately control the execution of git statistics gathering, allowing more granular control over which scan modules are enabled.

Enhancements:
- Refactor the subprocess call for Semgrep scanning to improve compatibility with pipx installations by using a more direct method of invoking the scan command.