### PR TITLE
bucket size in gcp

### DIFF
--- a/src/verinfast/cloud/gcp/blocks.py
+++ b/src/verinfast/cloud/gcp/blocks.py
@@ -1,10 +1,11 @@
 import json
 import os
 import time
-from utils import std_exec
 
 from google.cloud.monitoring_v3 import MetricServiceClient, TimeInterval, ListTimeSeriesRequest  # noqa: E501
 from google.cloud import storage
+
+from verinfast.utils.utils import std_exec
 
 
 def get_bucket_size(bucket_name):


### PR DESCRIPTION
<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

VerinFast GCP scan doesn't get size of buckets

<!-- Please give a short summary of the change and the problem this solves. -->

VerinFast GCP scan doesn't get size of buckets

## Related issue number

https://nichols.atlassian.net/browse/SOS-750

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

## Summary by Sourcery

New Features:
- Add functionality to retrieve the size of GCP storage buckets using the gcloud CLI.