### PR TITLE
Error checking on package-lock walker

### DIFF
--- a/src/verinfast/dependencies/walkers/package_lock.py
+++ b/src/verinfast/dependencies/walkers/package_lock.py
@@ -11,6 +11,7 @@ class PackageWalker(Walker):
         if not isinstance(resp, dict):
             self.log(f"Error with {entry.name} {entry.specifier} response")
             self.log(license_resp)
+            return
         entry.license = resp.get("license", "License not available")
         entry.summary = resp.get("description", "No description provided.")
 

--- a/src/verinfast/dependencies/walkers/package_lock.py
+++ b/src/verinfast/dependencies/walkers/package_lock.py
@@ -23,16 +23,15 @@ class PackageWalker(Walker):
                     dependencies = d["dependencies"]
                     for dependency in dependencies:
                         try:
-                            if isinstance(dependencies[dependency], dict):
-                                e = Entry(
-                                    name=dependency,
-                                    specifier=dependencies[dependency].get(
-                                        "version", "Version not found"
-                                    ),
-                                    source="package-lock.json"
-                                )
-                                self.remote_decorate(entry=e)
-                                self.entries.append(e)
+                            e = Entry(
+                                name=dependency,
+                                specifier=dependencies[dependency].get(
+                                    "version", "Version not found"
+                                ),
+                                source="package-lock.json"
+                            )
+                            self.remote_decorate(entry=e)
+                            self.entries.append(e)
                         except Exception as error:
                             self.log(f"error parsing {dependency}")
                             self.log(error)

--- a/src/verinfast/dependencies/walkers/package_lock.py
+++ b/src/verinfast/dependencies/walkers/package_lock.py
@@ -8,8 +8,11 @@ class PackageWalker(Walker):
         resp = None
         license_resp = self.getUrl(f"https://registry.npmjs.org/{entry.name}/{entry.specifier}/")  # NOQA:E501
         resp = json.loads(license_resp)
-        entry.license = resp["license"]
-        entry.summary = resp["description"]
+        if not isinstance(resp, dict):
+            self.log(f"Error with {entry.name} {entry.specifier} response")
+            self.log(license_resp)
+        entry.license = resp.get("license", "License not available")
+        entry.summary = resp.get("description", "No description provided.")
 
     def parse(self, file: str, expand=False):
         try:
@@ -18,15 +21,21 @@ class PackageWalker(Walker):
                 if "dependencies" in d:
                     dependencies = d["dependencies"]
                     for dependency in dependencies:
-
-                        e = Entry(
-                            name=dependency,
-                            specifier=dependencies[dependency]["version"],
-                            source="package-lock.json"
-                        )
-                        self.remote_decorate(entry=e)
-                        self.entries.append(e)
-
+                        try:
+                            if isinstance(dependencies[dependency], dict):
+                                e = Entry(
+                                    name=dependency,
+                                    specifier=dependencies[dependency].get(
+                                        "version", "Version not found"
+                                    ),
+                                    source="package-lock.json"
+                                )
+                                self.remote_decorate(entry=e)
+                                self.entries.append(e)
+                        except Exception as error:
+                            self.log(f"error parsing {dependency}")
+                            self.log(error)
+                            continue
         except Exception as error:
             # handle the exception
             self.log(f"error parsing {file}")

--- a/src/verinfast/dependencies/walkers/package_lock.py
+++ b/src/verinfast/dependencies/walkers/package_lock.py
@@ -8,12 +8,12 @@ class PackageWalker(Walker):
         resp = None
         license_resp = self.getUrl(f"https://registry.npmjs.org/{entry.name}/{entry.specifier}/")  # NOQA:E501
         resp = json.loads(license_resp)
-        if not isinstance(resp, dict):
+        if isinstance(resp, dict):
+            entry.license = resp.get("license", "License not available")
+            entry.summary = resp.get("description", "No description provided.")
+        else:
             self.log(f"Error with {entry.name} {entry.specifier} response")
             self.log(license_resp)
-            return
-        entry.license = resp.get("license", "License not available")
-        entry.summary = resp.get("description", "No description provided.")
 
     def parse(self, file: str, expand=False):
         try:


### PR DESCRIPTION
<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

For regression testing, package-lock walker had much lower dependency counts, ~700 vs ~1,100.  With error checking its now ~1,400 to 1,100, but package-lock seems more accurate.

npm:
![image](https://github.com/user-attachments/assets/7e4b6ff5-3271-48fa-b196-7f3ff23a06b1)

package-lock:
![image](https://github.com/user-attachments/assets/f5b738ca-03ae-49d5-a8d9-4f777f301b79)


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

## Summary by Sourcery

Implement error checking in the package-lock walker to handle unexpected response formats and missing fields from the npm registry, improving robustness and logging.

Bug Fixes:
- Add error handling for non-dictionary responses from the npm registry to prevent crashes.
- Ensure that missing license and description fields in npm responses are handled gracefully.

Enhancements:
- Improve logging to provide more detailed error messages when parsing dependencies.