### PR TITLE
Update walk.py to support Poetry

### DIFF
--- a/src/verinfast/dependencies/walk.py
+++ b/src/verinfast/dependencies/walk.py
@@ -60,7 +60,12 @@ def walk(logger, path: str = "./", output_file="./dependencies.json"):
     )
 
     py_walker = PyWalker(
-        manifest_files=["requirements.txt", "requirements-dev.txt", "pyproject.toml", "poetry.lock"],
+        manifest_files=[
+            "requirements.txt",
+            "requirements-dev.txt",
+            "pyproject.toml",
+            "poetry.lock"
+        ],
         manifest_type="txt",
         logger=logger,
         root_dir=path

--- a/src/verinfast/dependencies/walk.py
+++ b/src/verinfast/dependencies/walk.py
@@ -60,7 +60,7 @@ def walk(logger, path: str = "./", output_file="./dependencies.json"):
     )
 
     py_walker = PyWalker(
-        manifest_files=["requirements.txt", "requirements-dev.txt"],
+        manifest_files=["requirements.txt", "requirements-dev.txt", "pyproject.toml", "poetry.lock"],
         manifest_type="txt",
         logger=logger,
         root_dir=path


### PR DESCRIPTION
Poetry does not store it's dependencies in requirements.txt

<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

## Summary by Sourcery

Enhancements:
- Extend PyWalker to recognize 'pyproject.toml' and 'poetry.lock' as manifest files.