### PR TITLE
AWS costs fix for result limit

### DIFF
--- a/src/verinfast/cloud/aws/costs.py
+++ b/src/verinfast/cloud/aws/costs.py
@@ -7,11 +7,12 @@ from verinfast.cloud.aws.get_profile import find_profile
 def runAws(targeted_account, start, end, path_to_output, log,
            profile=None, dry=False):
 
-    def _get_costs_and_usage(profile: str, aws_output_file: str):
+    def _get_costs_and_usage(profile: str, aws_output_file: str,
+                             granularity='MONTHLY'):
         cmd = f'''
             aws ce get-cost-and-usage \
             --time-period Start={start},End={end} \
-            --granularity=DAILY \
+            --granularity={granularity} \
             --metrics "BlendedCost" \
             --group-by Type=DIMENSION,Key=SERVICE \
             --profile="{profile}" \

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -42,7 +42,7 @@ def test_aws_scan(self):
     assert Path(results_dir).exists() is True
     with open(results_dir.joinpath(f"aws-cost-{sub_id}.json")) as f:
         costs = json.load(f)
-        assert len(costs["data"]) >= 100
+        assert len(costs["data"]) >= 50
     # Make sure "aws-cost-foo.json" doesn't exist
     bad_costs_file = Path(results_dir.joinpath("aws-cost-foo.json"))
     assert not bad_costs_file.is_file()
@@ -119,7 +119,7 @@ def test_aws_dash(self):
     assert Path(results_dir).exists() is True
     with open(results_dir.joinpath(f"aws-cost-{sub_id}.json")) as f:
         costs = json.load(f)
-        assert len(costs["data"]) >= 100
+        assert len(costs["data"]) >= 50
     with open(results_dir.joinpath(f"aws-instances-{sub_id}.json")) as f:
         instances = json.load(f)
         assert len(instances["data"]) >= 5


### PR DESCRIPTION
<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

AWS CLI limits cost entries returned for get_cost_and_usage to 5,0000 records. This change decreases the granularity to MONTHLY which will fix it.

I tested it and uploaded. 

Former run with daily:
![image](https://github.com/user-attachments/assets/657278d5-7f95-4ab2-8074-e9d499627639)


New run with monthly:
![image](https://github.com/user-attachments/assets/ed9023a0-4725-4ff3-b94b-66c8cc1df920)


We could add this to the config and passthrough, etc. but in the entire history of the product, no on has looked at costs on a daily basis. And if we continue to support daily, we need to solve the 5K limit.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

## Summary by Sourcery

Bug Fixes:
- Fix AWS cost retrieval by changing granularity from DAILY to MONTHLY to avoid exceeding the AWS CLI limit of 5,000 records.