### PR TITLE
Fix findings upload during dry

### DIFF
--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -434,7 +434,6 @@ class Agent:
                          """)
 
             findings_output_file = os.path.join(self.config.output_dir, repo_name + ".findings.json")
-            findings_error_file = os.path.join(self.config.output_dir, repo_name + ".findings.err")
             findings_success = False
             if not self.config.dry:
                 self.log(msg=repo_name, tag="Scanning repository", display=True)
@@ -522,11 +521,15 @@ class Agent:
                                 {findings_output_file}
                             '''
                         )
-                self.upload(
-                    file=findings_output_file,
-                    route="findings",
-                    source=repo_name
-                )
+            # End if findings_success is True
+
+            # Upload findings always, in case of dry run
+            # .upload checks should_upload
+            self.upload(
+                file=findings_output_file,
+                route="findings",
+                source=repo_name
+            )
 
         # ##### Scan Dependencies ######
         if self.config.runDependencies:

--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -332,12 +332,12 @@ class Agent:
                 template_definition["gitlog"] = finalArr
                 # End if not self.config.dry:
 
-        if Path(git_output_file).exists():
-            self.upload(
-                file=git_output_file,
-                route="git",
-                source=repo_name
-            )
+        # if Path(git_output_file).exists():
+        self.upload(
+            file=git_output_file,
+            route="git",
+            source=repo_name
+        )
 
         # Manual File Sizes and Info
         sizes_output_file = os.path.join(self.config.output_dir, repo_name + ".sizes.json")

--- a/tests/test_dry.py
+++ b/tests/test_dry.py
@@ -61,6 +61,6 @@ def test_no_config(self):
     assert upload_fail_prefix + "small-test-repo.git.git.log.json" in logText
     assert upload_fail_prefix + "small-test-repo.git.sizes.json" in logText
     assert upload_fail_prefix + "small-test-repo.git.stats.json" in logText
-    assert upload_fail_prefix + "small-test-repo.git.finding.json" in logText
+    assert upload_fail_prefix + "small-test-repo.git.findings.json" in logText
     assert (upload_fail_prefix + "small-test-repo.git.dependencies.json"
             in logText)

--- a/tests/test_dry.py
+++ b/tests/test_dry.py
@@ -37,9 +37,30 @@ def test_no_config(self):
     assert get_url == "/report/uuid/9a6e8696-f93a-4402-a64e-342ccb37592b/CorsisCode", get_url  # noqa: E501
     agent.scan()
     assert Path(results_dir).exists()
-    files = os.listdir(results_dir)
-    assert len(files) == 1
+    # Make sure there are no .json results files
+    results_path = Path(results_dir)
+    assert results_path.exists()
+
+    # Check if there are any JSON files
+    json_files = list(results_path.glob("*.json"))
+    assert not json_files, f"Found JSON files: {json_files}"
+    # Since this test creates it's on DebubLog, the results
+    # dir will have two log files. One is timestamped and is
+    # the start of the regular log the the agent creates on start.
+    # The other is the debug log created by this test, "log.txt"
+    assert "/log.txt" in agent.debug.file
     with open(agent.debug.file) as f:
         logText = f.read()
-        assert "Error" not in logText
-        assert "File does not exist:" in logText
+    assert "Error" not in logText
+    assert "File does not exist:" in logText
+    # Since this test does not run a real scan, the debug log
+    # will have errors about file uploads. Confirm it attempts
+    # to upload all the files.
+    upload_fail_prefix = "File does not exist: "
+    upload_fail_prefix = upload_fail_prefix + str(results_dir) + "/"
+    assert upload_fail_prefix + "small-test-repo.git.git.log.json" in logText
+    assert upload_fail_prefix + "small-test-repo.git.sizes.json" in logText
+    assert upload_fail_prefix + "small-test-repo.git.files.json" in logText
+    assert upload_fail_prefix + "small-test-repo.git.finding.json" in logText
+    assert (upload_fail_prefix + "small-test-repo.git.dependencies.json"
+            in logText)

--- a/tests/test_dry.py
+++ b/tests/test_dry.py
@@ -9,7 +9,8 @@ from verinfast.utils.utils import DebugLog
 
 file_path = Path(__file__)
 test_folder = file_path.parent.absolute()
-results_dir = test_folder.joinpath("results").absolute()
+# To run unit tests in parallel, this test needs its own results directory
+results_dir = test_folder.joinpath("results_dry").absolute()
 str_path = str(test_folder.joinpath('str_conf.yaml').absolute())
 
 

--- a/tests/test_dry.py
+++ b/tests/test_dry.py
@@ -9,8 +9,7 @@ from verinfast.utils.utils import DebugLog
 
 file_path = Path(__file__)
 test_folder = file_path.parent.absolute()
-# To run unit tests in parallel, this test needs its own results directory
-results_dir = test_folder.joinpath("results_dry").absolute()
+results_dir = test_folder.joinpath("results").absolute()
 str_path = str(test_folder.joinpath('str_conf.yaml').absolute())
 
 

--- a/tests/test_dry.py
+++ b/tests/test_dry.py
@@ -60,7 +60,7 @@ def test_no_config(self):
     upload_fail_prefix = upload_fail_prefix + str(results_dir) + "/"
     assert upload_fail_prefix + "small-test-repo.git.git.log.json" in logText
     assert upload_fail_prefix + "small-test-repo.git.sizes.json" in logText
-    assert upload_fail_prefix + "small-test-repo.git.files.json" in logText
+    assert upload_fail_prefix + "small-test-repo.git.stats.json" in logText
     assert upload_fail_prefix + "small-test-repo.git.finding.json" in logText
     assert (upload_fail_prefix + "small-test-repo.git.dependencies.json"
             in logText)


### PR DESCRIPTION
<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

A November release had changes to fix the scan from crashing when the machine had no Internet access. These changes accidentally introduced a bug where the findings file would not upload on a "dry" run.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ x ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ x ] I've made sure all auto checks have passed.

## Summary by Sourcery

Bug Fixes:
- Fixed a bug where the findings file was not uploaded during dry runs.