### PR TITLE
Removed an exit that would stop trying other repos

### DIFF
--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -635,7 +635,6 @@ class Agent:
                             subprocess.check_output(["git", "clone", repo_url, temp_dir])
                         except subprocess.CalledProcessError:
                             self.log(msg=repo_url, tag="Failed to clone", display=True)
-                            exit(1)
                             continue
 
                         self.log(msg=repo_url, tag="Successfully cloned", display=True)


### PR DESCRIPTION
<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This exit was legacy QA code. It would prevent running other repos if a repo had a typo.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## Summary by Sourcery

Bug Fixes:
- Prevent premature exit when cloning a repository fails due to a typo.