### PR TITLE
pin findings, package-lock fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,5 @@ pytest~=8.3.4
 pytest-cov~=6.0.0
 pytest-xdist~=3.6.1
 pyyaml~=6.0.2
-semgrep~=1.103.0
+semgrep==1.103.0
 windows-curses~=2.4.0; sys.platform == 'win32'

--- a/src/verinfast/dependencies/walkers/package_lock.py
+++ b/src/verinfast/dependencies/walkers/package_lock.py
@@ -19,6 +19,8 @@ class PackageWalker(Walker):
             entry.license = resp.get("license", "License not available")
             entry.summary = resp.get("description", "No description provided.")
         else:
+            entry.license = "License not available"
+            entry.summary = "No description provided."
             self.log(f"Error with {entry.name} {entry.specifier} response")
             self.log(license_resp)
 


### PR DESCRIPTION
<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Two fixes included here:
1. Pinning the version of the findings module
2. The package-lock dependency scan was creating entries without "summary" (if the license returned has no summary) and this breaks uploads.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

## Summary by Sourcery

Pin the `semgrep` dependency to version 1.103.0 and handle missing license summaries in `package-lock` dependency scans.

Bug Fixes:
- Handle cases where the license summary is missing during `package-lock` dependency scans, preventing upload failures.

Enhancements:
- Pin the `semgrep` dependency to version 1.103.0.