### PR TITLE
sys info using hyfetch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ pygments-tsx>=1.0.1
 pytest~=8.3.4
 pytest-cov~=6.0.0
 pytest-xdist~=3.6.1
+psutil~=5.9.8
 pyyaml~=6.0.2
 semgrep==1.104.0
 windows-curses~=2.4.0; sys.platform == 'win32'

--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -98,15 +98,15 @@ class Agent:
         if self.config.modules is not None:
             self.system_info = get_system_info()
 
-            system_info_file = os.path.join(self.config.output_dir, "system_info.json")
-            with open(system_info_file, 'w') as f:
-                json.dump(self.system_info, f, indent=4)
-
-            self.upload(
-                file=system_info_file,
-                route="system_info",
-                source="System Information"
-            )
+            self.log(msg=json.dumps(self.system_info, indent=4), tag="System Information")
+            if not self.config.dry:
+                system_info_file = os.path.join(self.config.output_dir, "system_info.json")
+                try:
+                    with open(system_info_file, 'w') as f:
+                        json.dump(self.system_info, f, indent=4)
+                except IOError as e:
+                    self.log(f"Failed to write system info to {system_info_file}: {str(e)}")
+                    raise RuntimeError(f"Failed to write system information: {str(e)}") from e
 
             if self.config.modules.code is not None:
 

--- a/src/verinfast/agent.py
+++ b/src/verinfast/agent.py
@@ -21,6 +21,7 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from pygments_tsx.tsx import patch_pygments
 
 from verinfast.utils.utils import DebugLog, std_exec, trimLineBreaks, escapeChars, truncate, truncate_children, get_repo_name_url_and_branch
+from verinfast.system.sysinfo import get_system_info
 from verinfast.upload import Uploader
 from verinfast.cloud.aws.costs import get_aws_costs
 from verinfast.cloud.aws.get_profile import find_profile
@@ -95,6 +96,18 @@ class Agent:
 
     def scan(self):
         if self.config.modules is not None:
+            self.system_info = get_system_info()
+
+            system_info_file = os.path.join(self.config.output_dir, "system_info.json")
+            with open(system_info_file, 'w') as f:
+                json.dump(self.system_info, f, indent=4)
+
+            self.upload(
+                file=system_info_file,
+                route="system_info",
+                source="System Information"
+            )
+
             if self.config.modules.code is not None:
 
                 if self.config.shouldUpload:

--- a/src/verinfast/system/sysinfo.py
+++ b/src/verinfast/system/sysinfo.py
@@ -18,10 +18,16 @@ def get_system_info() -> Dict[str, Any]:
         "Hostname": platform.node(),
         "CPU Cores": psutil.cpu_count(logical=False),
         "Logical CPUs": psutil.cpu_count(logical=True),
-        "Total RAM": f"{round(psutil.virtual_memory().total / (1024**3), 2)} GB",
-        "Available RAM": f"{round(psutil.virtual_memory().available / (1024**3), 2)} GB",
+        "Total RAM": (
+            f"{round(psutil.virtual_memory().total / (1024**3), 2)} GB"
+        ),
+        "Available RAM": (
+            f"{round(psutil.virtual_memory().available / (1024**3), 2)} GB"
+        ),
         "Used RAM": f"{round(psutil.virtual_memory().used / (1024**3), 2)} GB",
-        "Disk Size": f"{round(shutil.disk_usage('/').total / (1024**3), 2)} GB",
+        "Disk Size": (
+            f"{round(shutil.disk_usage('/').total / (1024**3), 2)} GB"
+        ),
         "Disk Used": f"{round(shutil.disk_usage('/').used / (1024**3), 2)} GB",
         "Disk Free": f"{round(shutil.disk_usage('/').free / (1024**3), 2)} GB",
         "Python Version": platform.python_version(),

--- a/src/verinfast/system/sysinfo.py
+++ b/src/verinfast/system/sysinfo.py
@@ -1,71 +1,28 @@
-import json
-import subprocess
 from typing import Dict, Any
 import platform
-import os
+import psutil
+import shutil
 
 
 def get_system_info() -> Dict[str, Any]:
     """
-    Collects system information using hyfetch and
+    Collects system information and
     returns it as a JSON-compatible dictionary.
-    Falls back to basic system info if hyfetch fails.
     """
-    try:
-        # Run hyfetch with a 5 second timeout
-        result = subprocess.run(
-            ["hyfetch"],
-            capture_output=True,
-            text=True,
-            # check=True,
-            timeout=15  # 15 second timeout
-        )
-
-        # Process the output
-        lines = result.stdout.split("\n")
-        info = {}
-
-        for line in lines:
-            if ":" in line:
-                key, value = line.split(":", 1)
-                # Convert keys to snake_case and remove spaces
-                key = key.strip().lower().replace(" ", "_")
-                info[key] = value.strip()
-
-        # Add additional system information
-        info.update(_get_additional_info())
-
-        print(json.dumps(info, indent=4))
-
-    except (subprocess.CalledProcessError, FileNotFoundError,
-            subprocess.TimeoutExpired) as e:
-        # Fallback to basic system info if hyfetch fails,
-        #  isn't installed, or times out
-        info = {
-            "error": f"Failed to run hyfetch: {str(e)}",
-            "system_info": _get_additional_info()
-        }
-
-    return info
-
-
-def _get_additional_info() -> Dict[str, Any]:
-    """
-    Collects additional system information
-    using platform (Python's built-in libraries.
-    """
-    uname = platform.uname()
-
     return {
-        "os": uname.system,
-        "os_release": uname.release,
-        "os_version": uname.version,
-        "architecture": uname.machine,
-        "processor": uname.processor,
-        "hostname": uname.node,
-        "python_version": platform.python_version(),
-        "cpu_count": os.cpu_count(),
-        "platform": platform.platform(),
-        "cpu_architecture": platform.machine(),
-        "python_implementation": platform.python_implementation()
+        "OS": platform.system(),
+        "OS Version": platform.version(),
+        "OS Release": platform.release(),
+        "Machine": platform.machine(),
+        "Processor": platform.processor(),
+        "Hostname": platform.node(),
+        "CPU Cores": psutil.cpu_count(logical=False),
+        "Logical CPUs": psutil.cpu_count(logical=True),
+        "Total RAM": f"{round(psutil.virtual_memory().total / (1024**3), 2)} GB",
+        "Available RAM": f"{round(psutil.virtual_memory().available / (1024**3), 2)} GB",
+        "Used RAM": f"{round(psutil.virtual_memory().used / (1024**3), 2)} GB",
+        "Disk Size": f"{round(shutil.disk_usage('/').total / (1024**3), 2)} GB",
+        "Disk Used": f"{round(shutil.disk_usage('/').used / (1024**3), 2)} GB",
+        "Disk Free": f"{round(shutil.disk_usage('/').free / (1024**3), 2)} GB",
+        "Python Version": platform.python_version(),
     }

--- a/src/verinfast/system/sysinfo.py
+++ b/src/verinfast/system/sysinfo.py
@@ -1,0 +1,71 @@
+import json
+import subprocess
+from typing import Dict, Any
+import platform
+import os
+
+
+def get_system_info() -> Dict[str, Any]:
+    """
+    Collects system information using hyfetch and
+    returns it as a JSON-compatible dictionary.
+    Falls back to basic system info if hyfetch fails.
+    """
+    try:
+        # Run hyfetch with a 5 second timeout
+        result = subprocess.run(
+            ["hyfetch"],
+            capture_output=True,
+            text=True,
+            # check=True,
+            timeout=15  # 15 second timeout
+        )
+
+        # Process the output
+        lines = result.stdout.split("\n")
+        info = {}
+
+        for line in lines:
+            if ":" in line:
+                key, value = line.split(":", 1)
+                # Convert keys to snake_case and remove spaces
+                key = key.strip().lower().replace(" ", "_")
+                info[key] = value.strip()
+
+        # Add additional system information
+        info.update(_get_additional_info())
+
+        print(json.dumps(info, indent=4))
+
+    except (subprocess.CalledProcessError, FileNotFoundError,
+            subprocess.TimeoutExpired) as e:
+        # Fallback to basic system info if hyfetch fails,
+        #  isn't installed, or times out
+        info = {
+            "error": f"Failed to run hyfetch: {str(e)}",
+            "system_info": _get_additional_info()
+        }
+
+    return info
+
+
+def _get_additional_info() -> Dict[str, Any]:
+    """
+    Collects additional system information
+    using platform (Python's built-in libraries.
+    """
+    uname = platform.uname()
+
+    return {
+        "os": uname.system,
+        "os_release": uname.release,
+        "os_version": uname.version,
+        "architecture": uname.machine,
+        "processor": uname.processor,
+        "hostname": uname.node,
+        "python_version": platform.python_version(),
+        "cpu_count": os.cpu_count(),
+        "platform": platform.platform(),
+        "cpu_architecture": platform.machine(),
+        "python_implementation": platform.python_implementation()
+    }

--- a/src/verinfast/upload.py
+++ b/src/verinfast/upload.py
@@ -39,7 +39,8 @@ class Uploader:
             "scan_id": f"{report}{code_sep}",
             "logs": f"{report}/agent_logs",
             "err_stats": f"{report}/agent_err/stats_err",
-            "err_findings": f"{report}/agent_err/findings_err"
+            "err_findings": f"{report}/agent_err/findings_err",
+            "system_info": f"{report}/system_info"
         }
 
         if report is None:

--- a/src/verinfast/upload.py
+++ b/src/verinfast/upload.py
@@ -40,7 +40,6 @@ class Uploader:
             "logs": f"{report}/agent_logs",
             "err_stats": f"{report}/agent_err/stats_err",
             "err_findings": f"{report}/agent_err/findings_err",
-            "system_info": f"{report}/system_info"
         }
 
         if report is None:

--- a/tests/aws_conf.yaml
+++ b/tests/aws_conf.yaml
@@ -2,8 +2,8 @@ modules:
     cloud:
       - provider: aws
         account: 436708548746
-        start: "2024-01-01"
-        end: "2024-07-01"
+        start: "2024-12-01"
+        end: "2025-03-01"
       - provider: aws
         start: "2024-12-01"
         end: "2025-03-01"

--- a/tests/aws_conf.yaml
+++ b/tests/aws_conf.yaml
@@ -5,6 +5,6 @@ modules:
         start: "2024-01-01"
         end: "2024-07-01"
       - provider: aws
-        start: "2024-01-01"
-        end: "2024-07-01"
+        start: "2024-12-01"
+        end: "2025-03-01"
         account: "foo" #Account with no profile

--- a/tests/aws_dash.yaml
+++ b/tests/aws_dash.yaml
@@ -2,5 +2,5 @@ modules:
     cloud:
       - provider: aws
         account: 4367-0854-8746
-        start: "2024-01-01"
-        end: "2024-07-01"
+        start: "2024-12-01"
+        end: "2025-03-01"

--- a/tests/test_sysinfo.py
+++ b/tests/test_sysinfo.py
@@ -1,38 +1,10 @@
 from verinfast.system.sysinfo import get_system_info
-import subprocess
 import json
-
-
-def test_hyfetch_installation():
-    """Test if hyfetch is installed and can run directly"""
-    print("\nTesting hyfetch installation:")
-    try:
-        # Try to run hyfetch directly with timeout
-        result = subprocess.run(
-            ["hyfetch", "--version"],
-            capture_output=True,
-            text=True,
-            timeout=15
-        )
-        print(f"Hyfetch is installed. Version output: {result.stdout.strip()}")
-        return True
-    except FileNotFoundError:
-        print("Hyfetch is not installed")
-        return False
-    except subprocess.TimeoutExpired:
-        print("Hyfetch command timed out")
-        return False
-    except Exception as e:
-        print(f"Unexpected error running hyfetch: {str(e)}")
-        return False
 
 
 def test_system_info_comprehensive():
     """Comprehensive test of system information collection"""
     print("\nTesting system information collection:")
-
-    # First check if hyfetch is installed
-    hyfetch_available = test_hyfetch_installation()
 
     # Get system information
     info = get_system_info()
@@ -41,37 +13,26 @@ def test_system_info_comprehensive():
     print("\nCollected System Information:")
     print(json.dumps(info, indent=4))
 
-    # Analyze the response
-    if "error" in info:
-        print(f"\nFallback mechanism was triggered: {info['error']}")
-        if hyfetch_available:
-            print("WARNING: Hyfetch is installed but failed to run properly")
-        info = info["system_info"]  # Use fallback info for validation
-    else:
-        print("\nHyfetch ran successfully")
-
     # Validate the information
     assert isinstance(info, dict), "System info should be a dictionary"
     assert len(info) > 0, "System info should not be empty"
 
     # Check for essential keys
     essential_keys = [
-        "os",
-        "os_release",
-        "architecture",
-        "python_version",
-        "cpu_count",
-        "platform",
-        "processor"
+        "OS",
+        "OS Version",
+        "OS Release",
+        "Machine",
+        "Processor",
+        "CPU Cores",
+        "Total RAM",
+        "Python Version"
     ]
 
     print("\nValidating essential system information:")
     for key in essential_keys:
-        if key in info:
-            print(f"✓ {key}: {info[key]}")
-        else:
-            print(f"✗ Missing: {key}")
-            assert False, f"Missing essential key: {key}"
+        assert key in info, f"Missing essential key: {key}"
+        print(f"✓ {key}: {info[key]}")
 
     # Print summary
     print(f"\nTotal fields collected: {len(info)}")

--- a/tests/test_sysinfo.py
+++ b/tests/test_sysinfo.py
@@ -1,0 +1,82 @@
+from verinfast.system.sysinfo import get_system_info
+import subprocess
+import json
+
+
+def test_hyfetch_installation():
+    """Test if hyfetch is installed and can run directly"""
+    print("\nTesting hyfetch installation:")
+    try:
+        # Try to run hyfetch directly with timeout
+        result = subprocess.run(
+            ["hyfetch", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=15
+        )
+        print(f"Hyfetch is installed. Version output: {result.stdout.strip()}")
+        return True
+    except FileNotFoundError:
+        print("Hyfetch is not installed")
+        return False
+    except subprocess.TimeoutExpired:
+        print("Hyfetch command timed out")
+        return False
+    except Exception as e:
+        print(f"Unexpected error running hyfetch: {str(e)}")
+        return False
+
+
+def test_system_info_comprehensive():
+    """Comprehensive test of system information collection"""
+    print("\nTesting system information collection:")
+
+    # First check if hyfetch is installed
+    hyfetch_available = test_hyfetch_installation()
+
+    # Get system information
+    info = get_system_info()
+
+    # Print formatted output for visual inspection
+    print("\nCollected System Information:")
+    print(json.dumps(info, indent=4))
+
+    # Analyze the response
+    if "error" in info:
+        print(f"\nFallback mechanism was triggered: {info['error']}")
+        if hyfetch_available:
+            print("WARNING: Hyfetch is installed but failed to run properly")
+        info = info["system_info"]  # Use fallback info for validation
+    else:
+        print("\nHyfetch ran successfully")
+
+    # Validate the information
+    assert isinstance(info, dict), "System info should be a dictionary"
+    assert len(info) > 0, "System info should not be empty"
+
+    # Check for essential keys
+    essential_keys = [
+        "os",
+        "os_release",
+        "architecture",
+        "python_version",
+        "cpu_count",
+        "platform",
+        "processor"
+    ]
+
+    print("\nValidating essential system information:")
+    for key in essential_keys:
+        if key in info:
+            print(f"✓ {key}: {info[key]}")
+        else:
+            print(f"✗ Missing: {key}")
+            assert False, f"Missing essential key: {key}"
+
+    # Print summary
+    print(f"\nTotal fields collected: {len(info)}")
+    print("All validations passed!")
+
+
+if __name__ == "__main__":
+    test_system_info_comprehensive()


### PR DESCRIPTION
<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

To collect system info during scans 

<!-- Please give a short summary of the change and the problem this solves. -->

add hyfetch to verinfast to collect system data at run time

## Related issue number

sos-684

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

## Summary by Sourcery

Add system information collection during scans using hyfetch. If hyfetch is unavailable or fails, the agent will collect basic system information as a fallback.

New Features:
- Collect system information during scans and upload it as a JSON file.

Tests:
- Added tests to verify hyfetch installation and system information collection.