### PR TITLE
Simple fix for missing scan ID

### DIFF
--- a/src/verinfast/agent/core.py
+++ b/src/verinfast/agent/core.py
@@ -164,7 +164,7 @@ class Agent:
                         f"Failed to write system information: {str(e)}"
                     ) from e
 
-            if self.config.modules.code is not None:
+            if self.config.modules.code is not None or self.config.modules.cloud is not None:
                 if self.config.shouldUpload:
                     headers = {
                         "content-type": "application/json",


### PR DESCRIPTION
Another working PR for @ojokure

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the scan ID was not being uploaded when only the cloud module was enabled.