### PR TITLE
Cost_separator not code_separator

### DIFF
--- a/src/verinfast/upload.py
+++ b/src/verinfast/upload.py
@@ -25,7 +25,7 @@ class Uploader:
 
         code_sep = self.config.code_separator or ""
 
-        cost_sep = self.config.code_separator or ""
+        cost_sep = self.config.cost_separator or ""
 
         paths = {
             "git": f"{report}{code_sep}/{code}/{repo_name}/git",


### PR DESCRIPTION
<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Caught an issue with cloud uploads during regression testing. This was an area with a manual merge from the Black formatting. Looks like a type made it in.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

## Summary by Sourcery

Bug Fixes:
- Fixes a bug where the code separator was incorrectly used instead of the cost separator when constructing upload paths.