### PR TITLE
Wrong command line parameter for next-page-token, AWS get costs

### DIFF
--- a/src/verinfast/cloud/aws/costs.py
+++ b/src/verinfast/cloud/aws/costs.py
@@ -18,9 +18,8 @@ def get_aws_costs(
             --profile="{profile}" \
             --output=json"""
 
-        cmd = f'{base_cmd} --next-token="{next_token}" | cat'
         if next_token:
-            cmd = f'{base_cmd} --next-token="{next_token}" | cat'
+            cmd = f'{base_cmd} --next-page-token="{next_token}" | cat'
         else:
             cmd = f"{base_cmd} | cat"
 

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -69,7 +69,7 @@ def test_aws_costs_pagination(mock_subprocess_run, tmp_path):
 
     # Verify the second call included the NextPageToken
     second_call_args = mock_subprocess_run.call_args_list[1][0][0]
-    assert '--next-token="mock-token-123"' in second_call_args
+    assert '--next-page-token="mock-token-123"' in second_call_args
 
     # Verify the output file exists and contains combined data
     assert os.path.exists(output_file)


### PR DESCRIPTION
<!-- Thank you for your contribution!  -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Using the wrong parameter, see https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ce/get-cost-and-usage.html
Should be next-page-token, not next-token

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.