### PR TITLE
Consolidate open dependabot updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "azure-identity~=1.25.0",
+    "azure-identity~=1.25.1",
     "azure-mgmt-compute~=37.2.0",
     "azure-mgmt-monitor~=7.0.0",
     "azure-mgmt-network~=30.2.0",


### PR DESCRIPTION
## Summary

Handles all five open dependabot update PRs in a single branch that is branched directly off `main`, so there are no merge conflicts.

Four of the five dependabot PRs are already satisfied by the current `pyproject.toml` on `main` (which was bulk-updated in `e07c6b3` and `65e80a7`). Only `azure-identity` needed an actual bump, and that is the single change in this PR.

### Dependabot PR disposition

| PR | Package | Requested | `main` has | Status |
| --- | --- | --- | --- | --- |
| VerinFast/verinfast#811 | `boto3` | `~=1.40.62` | `~=1.42.0` | already newer — close |
| VerinFast/verinfast#795 | `azure-mgmt-compute` | `~=37.0.1` | `~=37.2.0` | already newer — close |
| VerinFast/verinfast#792 | `azure-identity` | `~=1.25.1` | `~=1.25.0` → `~=1.25.1` | **applied here** |
| VerinFast/verinfast#739 | `azure-mgmt-monitor` | `~=7.0.0` | `~=7.0.0` | already at requested — close |
| VerinFast/verinfast#741 | `azure-monitor-query` | `~=2.0.0` | `~=1.4.0` | **deferred — see below** |

### Why `azure-monitor-query` 2.0.0 is deferred

`azure-monitor-query` 2.0.0 [removes `MetricsQueryClient`](https://github.com/Azure/azure-sdk-for-python/releases/tag/azure-monitor-query_2.0.0) and moves metrics functionality into a new `azure-monitor-querymetrics` package (or `azure-mgmt-monitor`). `MetricsQueryClient` is used in:

- `src/verinfast/cloud/azure/blocks.py:6,14` (`query_resource(...)` for `UsedCapacity` on storage accounts)
- `src/verinfast/cloud/azure/instances.py:9,31,63` (`query_resource(...)` with aggregations for VM CPU metrics)

That's a non-trivial code migration (the response shapes and `timespan`/`aggregations` argument formats differ between `azure-monitor-query` and `azure-mgmt-monitor`/`azure-monitor-querymetrics`). It deserves its own reviewable, testable PR against real Azure credentials rather than being bundled into a dep-bump.

## Test plan

- [ ] CI passes on this branch
- [ ] `pip install -e .` resolves with the new constraint (`azure-identity>=1.25.1,<1.26`)
- [ ] After merge, confirm dependabot closes #811, #795, #792, and #739 as superseded / no longer applicable
- [ ] Track #741 (`azure-monitor-query` 2.0.0) separately as a code-migration task

https://claude.ai/code/session_01GkKdqUjHjbPaf4QZ6Vt6LD