### PR TITLE
Remove Corsis naming: default upload code_separator becomes /CodeScan

### DIFF
--- a/src/verinfast/config.py
+++ b/src/verinfast/config.py
@@ -91,7 +91,7 @@ class UploadConfig(printable):
 
     uuid: bool = False
     prefix: Union[str, None] = "/report/"
-    code_separator: Union[str, None] = "/CorsisCode"
+    code_separator: Union[str, None] = "/CodeScan"
     cost_separator: Union[str, None] = None
 
 

--- a/tests/test_dry.py
+++ b/tests/test_dry.py
@@ -37,6 +37,17 @@ def test_no_config(self):
     assert (
         get_url == "/report/uuid/9a6e8696-f93a-4402-a64e-342ccb37592b/CodeScan"
     ), get_url
+    # server.code_separator stays configurable for servers that expect a
+    # different segment (e.g. legacy deployments); prove the override is honored
+    default_separator = agent.uploader.config.code_separator
+    agent.uploader.config.code_separator = "/LegacySegment"
+    override_url = agent.uploader.make_upload_path(
+        "scan_id", report=agent.config.reportId
+    )
+    assert (
+        override_url == "/report/uuid/9a6e8696-f93a-4402-a64e-342ccb37592b/LegacySegment"
+    ), override_url
+    agent.uploader.config.code_separator = default_separator
     agent.scan()
     assert Path(results_dir).exists()
     # Make sure there are no .json results files

--- a/tests/test_dry.py
+++ b/tests/test_dry.py
@@ -35,7 +35,7 @@ def test_no_config(self):
     assert agent.config.use_uuid is True, f"Expected True, config {agent.config}"
     get_url = agent.uploader.make_upload_path("scan_id", report=agent.config.reportId)
     assert (
-        get_url == "/report/uuid/9a6e8696-f93a-4402-a64e-342ccb37592b/CorsisCode"
+        get_url == "/report/uuid/9a6e8696-f93a-4402-a64e-342ccb37592b/CodeScan"
     ), get_url
     agent.scan()
     assert Path(results_dir).exists()

--- a/tests/test_dry.py
+++ b/tests/test_dry.py
@@ -45,7 +45,8 @@ def test_no_config(self):
         "scan_id", report=agent.config.reportId
     )
     assert (
-        override_url == "/report/uuid/9a6e8696-f93a-4402-a64e-342ccb37592b/LegacySegment"
+        override_url
+        == "/report/uuid/9a6e8696-f93a-4402-a64e-342ccb37592b/LegacySegment"
     ), override_url
     agent.uploader.config.code_separator = default_separator
     agent.scan()


### PR DESCRIPTION
## Summary

Removes the last legacy-product-name references from the agent (a case-insensitive grep for it now returns nothing in this repo):

- `src/verinfast/config.py`: `UploadConfig.code_separator` default changes to `"/CodeScan"`, so default upload paths become `/report/uuid/{uuid}/CodeScan/...`.
- `tests/test_dry.py`: the scan-id path assertion updated to match, plus coverage proving a configured override is honored.

## Compatibility

- The segment stays fully configurable via `server.code_separator` in the config YAML, so a config targeting an older server can set the previous value explicitly.
- ATD v2 emits an explicit `server.code_separator` in its served agent config (`VerinFastConfig.yaml`), so **already-released agent versions remain compatible with the new server** — only agents run against v2 *without* a served config rely on this new default.
- ATD v2's ingest routes moved to `/CodeScan` in lockstep (VerinFast/atd_v2 #42 and the ingest PR queue).

## Verification

Path construction verified directly against `Uploader.make_upload_path` with the new default:

```
scan_id: /report/uuid/9a6e8696-f93a-4402-a64e-342ccb37592b/CodeScan
git:     /report/uuid/9a6e8696-.../CodeScan/SCANID/myrepo.git/git
```

An override (`server.code_separator`) was verified to produce the configured segment instead, so the compatibility path above is tested, not just asserted. A case-insensitive grep for the legacy names (excluding `.git`) returns no matches.

The full pytest suite couldn't run in this sandbox (agent dependency install blocked by a system-managed PyYAML); CI exercises `tests/test_dry.py`, which asserts both path shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4kmy9dYHpq9sA8pZwtEtQ